### PR TITLE
Chrome throws if console is open

### DIFF
--- a/lib/v8-browser-all.js
+++ b/lib/v8-browser-all.js
@@ -71,7 +71,7 @@
     }
 
     function testIsDebugging() {
-       var _test = function() { return true; };
+        var _test = function() { return true; };
         _test();
         v8.optimizeFunctionOnNextCall(_test);
         _test();

--- a/lib/v8-browser-all.js
+++ b/lib/v8-browser-all.js
@@ -73,7 +73,11 @@
     function testIsDebugging() {
         var _test = function() { return true; };
         _test();
-        v8.optimizeFunctionOnNextCall(_test);
+        try {
+            v8.optimizeFunctionOnNextCall(_test);
+        } catch (e) {
+            return true
+        }
         _test();
         var res = v8.getOptimizationStatus(_test);
         return !(res === 1 || res === 3);

--- a/lib/v8-browser.js
+++ b/lib/v8-browser.js
@@ -85,7 +85,11 @@
     function testIsDebugging() {
         var _test = function() { return true; };
         _test();
-        v8.optimizeFunctionOnNextCall(_test);
+        try {
+            v8.optimizeFunctionOnNextCall(_test);
+        } catch (e) {
+            return true
+        }
         _test();
         var res = v8.getOptimizationStatus(_test);
         return !(res === 1 || res === 3);

--- a/lib/v8-browser.js
+++ b/lib/v8-browser.js
@@ -83,7 +83,7 @@
     }
 
     function testIsDebugging() {
-       var _test = function() { return true; };
+        var _test = function() { return true; };
         _test();
         v8.optimizeFunctionOnNextCall(_test);
         _test();


### PR DESCRIPTION
Tested under Chrome Version 42.0.2299.0 canary (64-bit) on Mac OS 10.10.2